### PR TITLE
Define "errortitle" and "errordescr" params

### DIFF
--- a/lib/Auth/Source/X509userCert.php
+++ b/lib/Auth/Source/X509userCert.php
@@ -92,6 +92,12 @@ class X509userCert extends \SimpleSAML\Auth\Source
         $t->data['loginurl'] = Utils\HTTP::getSelfURL();
         $t->data['errorcode'] = $state['authX509.error'];
         $t->data['errorcodes'] = Error\ErrorCodes::getAllErrorCodeMessages();
+        $t->data['errortitle'] = $t->data['errorcode'];
+        if (array_key_exists($t->data['errorcode'], $t->data['errorcodes'])) {
+            $t->data['errordescr'] = $t->data['errorcodes'][$t->data['errorcode']];
+        } else {
+            $t->data['errordescr'] = $t->data['errorcode'];
+        }
 
         $t->send();
         exit();
@@ -167,7 +173,7 @@ class X509userCert extends \SimpleSAML\Auth\Source
         }
 
         $ldap_certs = $ldapcf->getAttributes($dn, $this->ldapusercert);
-        
+
         if (empty($ldap_certs)) {
             Logger::error('authX509: no certificate found in LDAP for dn=' . $dn);
             $state['authX509.error'] = "UNKNOWNCERT";

--- a/lib/Auth/Source/X509userCert.php
+++ b/lib/Auth/Source/X509userCert.php
@@ -87,16 +87,16 @@ class X509userCert extends \SimpleSAML\Auth\Source
     public function authFailed(&$state): void
     {
         $config = Configuration::getInstance();
+        $errorcode = $state['authX509.error'];
+        $errorcodes = Error\ErrorCodes::getAllErrorCodeMessages();
 
         $t = new Template($config, 'authX509:X509error.twig');
         $t->data['loginurl'] = Utils\HTTP::getSelfURL();
-        $t->data['errorcode'] = $state['authX509.error'];
-        $t->data['errorcodes'] = Error\ErrorCodes::getAllErrorCodeMessages();
-        $t->data['errortitle'] = $t->data['errorcode'];
-        if (array_key_exists($t->data['errorcode'], $t->data['errorcodes'])) {
-            $t->data['errordescr'] = $t->data['errorcodes'][$t->data['errorcode']];
+        $t->data['errortitle'] = $errorcode;
+        if (array_key_exists($errorcode, $errorcodes)) {
+            $t->data['errordescr'] = $errorcodes[$errorcode];
         } else {
-            $t->data['errordescr'] = $t->data['errorcode'];
+            $t->data['errordescr'] = $errorcode;
         }
 
         $t->send();

--- a/templates/X509error.twig
+++ b/templates/X509error.twig
@@ -2,9 +2,11 @@
 {% extends "base.twig" %}
 {% block content %}
 
-{% if errorcode -%}
 <h2>{% trans 'Error' %}</h2>
+{% if errortitle is defined -%}
 <h3>{% trans errortitle %}</h3>
+{% endif -%}
+{% if errordescr is defined -%}
 <p>{% trans errordescr %}</p>
 {% endif -%}
 


### PR DESCRIPTION
`simplesamlphp-module-authX509/templates/X509error.twig` contains references to *errortitle* and *errordescr* parameters. However they both are undefined. It should be in the method **authFailed** in: https://github.com/simplesamlphp/simplesamlphp-module-authX509/blob/3fcb6a060a1852495b4ec9ec740f623db8e0eba7/lib/Auth/Source/X509userCert.php#L87

This pull request addresses this issue by putting an error code and a corresponding error message if available.
