### PR TITLE
Allow anonymous LDAP connections

### DIFF
--- a/src/Auth/Source/X509userCert.php
+++ b/src/Auth/Source/X509userCert.php
@@ -277,8 +277,8 @@ class X509userCert extends Auth\Source
     {
         $searchBase = $this->ldapConfig->getArray('search.base');
 
-        $searchUsername = $this->ldapConfig->getString('search.username');
-        Assert::notWhitespaceOnly($searchUsername);
+        $searchUsername = $this->ldapConfig->getOptionalString('search.username', null);
+        Assert::nullOrnotWhitespaceOnly($searchUsername);
 
         $searchPassword = $this->ldapConfig->getOptionalString('search.password', null);
         Assert::nullOrnotWhitespaceOnly($searchPassword);


### PR DESCRIPTION
The LDAP authentication module allows for anonymous binds by setting both the username and password to 'null'.  

This patch updates authX509 to allow for the same functionality by changing the 'search.username' from being a required attribute to an optional one with a null default value (just as search.password already is).
